### PR TITLE
docs: credit Discussion authors in implementation PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ takes longer than implementing a proposal after we agree on it.
 2. Wait for a maintainer to review the proposal.
 3. If we accept it, a Mathematic maintainer or agent will open the implementation pull request.
 
+When Mathematic implements a proposal, the implementation pull request will link to the Discussion
+and credit its original author.
+
 GitHub restricts pull request creation to Mathematic maintainers and repository collaborators who
 have write, maintain, or admin access, plus authorized maintenance agents.
 

--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ To report a bug or propose a change, [start a GitHub Discussion](../../discussio
 review. If we accept the proposal, a Mathematic maintainer or agent will open the implementation pull
 request.
 
+When Mathematic implements a proposal, the implementation pull request will link to the Discussion
+and credit its original author.
+
 GitHub restricts pull request creation to Mathematic maintainers and repository collaborators who
 have write, maintain, or admin access, plus authorized maintenance agents. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the full process and development instructions.


### PR DESCRIPTION
## Summary

- state that implementation pull requests link to the accepted Discussion
- promise credit to the original proposal author

## Checks

- git diff --check
- confirmed the existing relative Discussion links remain unchanged