### PR TITLE
chore(deps): bump rumdl to 0.2.61

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -18,7 +18,7 @@ oxlint = { version = "1.80.0", depends = ["node"] }
 pinact = "4.1.1"
 pnpm = { version = "11.24.0", depends = ["node"] }
 python = "3.14.7"
-rumdl = "0.2.60"
+rumdl = "0.2.61"
 shellcheck = "0.11.0"
 shfmt = "3.13.1"
 tombi = "1.4.1"


### PR DESCRIPTION
## Summary

- bump the pinned rumdl version from 0.2.60 to 0.2.61

## Verification

- `mise -C . fmt --check`
- `pkl eval hk.pkl`
- `mise exec -- rumdl --version`
- `mise exec -- hk check --all --slow`
- `git diff --check`