### PR TITLE
fix(ci): harden release workflows and repository checks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
+        with:
+          source: ./docs
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./_site
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,52 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v1.12.0)"
+        description: Existing release tag
         required: true
         type: string
 
 concurrency:
-  group: release-notes-${{ github.event.inputs.tag }}
-  cancel-in-progress: true
+  group: release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   enhance:
-    name: Enhance release notes with Claude
+    name: Update release notes
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
-      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"
-          prompt: |
-            Write an exciting, polished GitHub release body for ts-japi ${{ inputs.tag }} and save it to `release-notes.md`.
-
-            ts-japi is a highly-modular, TypeScript-friendly, framework-agnostic library for serializing data to the JSON:API specification. It provides serializers, deserializers, error handling, pagination, sorting, filtering, and full relationship support.
-
-            Steps:
-            1. Run `git describe --tags --abbrev=0 HEAD^` to get the previous tag, then run `git log <previous-tag>..HEAD --oneline` to see all commits in this release.
-            2. Read `src/index.ts` and key source files under `src/` to understand the API surface.
-            3. Write the release body to `release-notes.md`. It should:
-               - Open with an enthusiastic one-paragraph summary of what's new or why this release is exciting.
-               - Have clearly labelled sections (e.g. **✨ New Features**, **🐛 Bug Fixes**, **⚡ Improvements**) — only include sections that actually have content.
-               - For any significant new feature, include a short TypeScript example snippet showing it in action.
-               - End with an installation snippet (`npm install ts-japi` or `pnpm add ts-japi`).
-               - Be written in an upbeat, developer-friendly tone — celebrate the work!
-            Do NOT publish it yourself — a subsequent step will do that.
-
-      - name: Publish release notes
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ inputs.tag }}
-          body_path: release-notes.md
+      - name: Generate notes for the existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null
+          gh api --method POST "repos/$GH_REPO/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" --jq .body > release-notes.md
+          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --notes-file release-notes.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release-please:
+    environment: release
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
             --field tag="$RELEASE_TAG"
 
   attest-provenance:
+    environment: release
     name: Attest Build Provenance
     needs:
       - create-release


### PR DESCRIPTION
Replace legacy Pages deployment with an explicit Jekyll build and current artifact actions, using the protected github-pages environment. Protect release creation, release notes, and provenance with the release environment, and generate release notes through GitHub's native API.

Validation: actionlint passed locally. CI, Analyze (actions), Build Pages, Check, Analyze (javascript-typescript), Node 20 engine floor, CodeQL all passed in GitHub at commit c4864fa44305c365ceebdfbcae3ec972f8b4f81d.
