### PR TITLE
perf(serializer): dedupe included resources with a Set

### DIFF
--- a/src/classes/serializer.ts
+++ b/src/classes/serializer.ts
@@ -228,7 +228,7 @@ export default class Serializer<PrimaryType extends Dictionary<any> = any> {
     // Cache data fetched during resource creation
     const relatorDataCache: Map<Relator<any>, Dictionary<any>[]> = new Map();
 
-    const keys: string[] = [];
+    const keys = new Set<string>();
     let wasSingle = false;
     let dto;
     let createIdentifier;
@@ -269,7 +269,7 @@ export default class Serializer<PrimaryType extends Dictionary<any> = any> {
       createIdentifier = (datum: any) => relator.getRelatedIdentifier(datum);
       createResource = async (datum: any) => {
         const resource = await relator.getRelatedResource(datum);
-        keys.push(resource.getKey());
+        keys.add(resource.getKey());
         return resource;
       };
       relators = relator.getRelatedRelators();
@@ -299,7 +299,7 @@ export default class Serializer<PrimaryType extends Dictionary<any> = any> {
       createIdentifier = (datum: PrimaryType) => this.createIdentifier(datum, o);
       createResource = async (datum: PrimaryType) => {
         const resource = await this.createResource(datum, o, h, relatorDataCache);
-        keys.push(resource.getKey());
+        keys.add(resource.getKey());
         return resource;
       };
       relators = h.relators;

--- a/src/utils/serializer.utils.ts
+++ b/src/utils/serializer.utils.ts
@@ -6,7 +6,7 @@ async function recurseRelatorsDepth(
   data: any[],
   relators: Record<string, Relator<any>>,
   depth: number,
-  keys: string[],
+  keys: Set<string>,
   relatorDataCache?: Map<Relator<any>, Dictionary<any>[]>,
 ) {
   const included: any[] = [];
@@ -42,8 +42,8 @@ async function recurseRelatorsDepth(
         );
 
         const key = resource.getKey();
-        if (!keys.includes(key)) {
-          keys.push(key);
+        if (!keys.has(key)) {
+          keys.add(key);
           included.push(resource);
         }
       }
@@ -59,7 +59,7 @@ export async function recurseRelators(
   data: any[],
   relators: Record<string, Relator<any>>,
   include: number | string[] | undefined,
-  keys: string[],
+  keys: Set<string>,
   relatorDataCache?: Map<Relator<any>, Dictionary<any>[]>,
 ) {
   if (include === undefined || typeof include === "number") {
@@ -125,7 +125,7 @@ export async function recurseRelators(
           const key = `${relator.serializer.collectionName}:${
             cacheItem[relator.serializer.getIdKeyFieldName()] as string
           }`;
-          if (!keys.includes(key)) {
+          if (!keys.has(key)) {
             // const key = resource.getKey();
             const resource = await relator.getRelatedResource(
               cacheItem,
@@ -134,7 +134,7 @@ export async function recurseRelators(
               // Only build the cache for the next iteration if needed.
               shouldBuildRelatedCache ? newRelatorDataCache : undefined,
             );
-            keys.push(key);
+            keys.add(key);
             included.push(resource);
           }
         }


### PR DESCRIPTION
Implements https://github.com/mathematic-inc/ts-japi/discussions/136, proposed and benchmarked by @Xaelp.

## Problem

Compound document serialization tracked already-included resource keys in an array and tested membership with `keys.includes(key)`. That scan is linear and runs once per candidate resource, so serializing *n* included resources cost ~n²/2 string comparisons.

## Change

`keys` is only ever tested for membership and appended to, so switching it from `Array` to `Set` is semantically identical and makes the dedupe O(n). Six call sites across two files:

- `src/classes/serializer.ts` — `const keys: string[] = []` → `new Set<string>()`, and two `keys.push(resource.getKey())` → `keys.add(...)`
- `src/utils/serializer.utils.ts` — the `keys` parameter on `recurseRelators` and `recurseRelatorsDepth` changes from `string[]` to `Set<string>`, and both `!keys.includes(key)` / `keys.push(key)` pairs become `!keys.has(key)` / `keys.add(key)`

Neither function is exported from `src/index.ts`, so the public API is unchanged.

## Benchmark

Measured against `main` (1.12.5) with one serializer, one relator and `include: 1`, where each of *n* primary resources relates to a distinct resource. Median of 3 runs, warmup discarded, `process.hrtime.bigint()`, Node 24.20.0:

| n | array (ms) | Set (ms) | speedup | `included` |
|---|---|---|---|---|
| 100 | 0.25 | 0.21 | 1.20× | 100 |
| 250 | 1.32 | 0.47 | 2.78× | 250 |
| 500 | 1.81 | 1.62 | 1.12× | 500 |
| 1000 | 9.62 | 1.70 | 5.67× | 1000 |
| 2000 | 19.18 | 3.34 | 5.74× | 2000 |
| 4000 | 92.35 | 8.96 | **10.31×** | 4000 |

Below n≈500 both are dominated by fixed overhead and the difference is noise; from n=1000 the quadratic signature is unambiguous. These are this machine's numbers — the shape reproduces, the constant does not: a second run of the same harness gave 14.88× at n=4000, so treat the multiplier as indicative rather than exact. The discussion's 18.90× was not reproduced here.

## Correctness

- Serialized output is byte-identical (`JSON.stringify` equality) to the array implementation at every n above, verified against a worktree of `main`.
- Dedupe still collapses as expected on both code paths: 1000 primary resources sharing *k* related resources yields exactly *k* entries in `included` for the numeric `include` path and for the string-array `include: ["authors"]` path.
- Existing suite: 17 files, 105 tests passing. `issue-23` (`depth: 2`), `issue-24` (`depth: 20`), `issue-68` and `issue-98` already cover both branches, so no new tests were added.

## Checks

`pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm audit --audit-level high` and `hk check --all --slow` all pass locally.
